### PR TITLE
fix: do not lowercase values

### DIFF
--- a/__snapshots__/test.spec.js.snap
+++ b/__snapshots__/test.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`End to End tests create issue 1`] = `
 "{
   \\"contact\\": \\"test@test.org\\",
-  \\"what_happened\\": \\"something\\",
+  \\"what_happened\\": \\"Something\\",
   \\"version\\": \\"1.0.2 (default)\\",
   \\"browsers\\": \\"\\",
   \\"relevant_log_output\\": \\"\\",
@@ -15,7 +15,7 @@ exports[`End to End tests create issue 1`] = `
 exports[`End to End tests create issue text only 1`] = `
 "{
   \\"contact\\": \\"test@test.org\\",
-  \\"what_happened\\": \\"something\\",
+  \\"what_happened\\": \\"Something\\",
   \\"version\\": \\"\\",
   \\"browsers\\": \\"\\",
   \\"relevant_log_output\\": \\"\\",

--- a/dist/index.js
+++ b/dist/index.js
@@ -4591,7 +4591,7 @@ function toValue(val) {
         return val;
     }
 
-    const value = val.toLowerCase().trim();
+    const value = val.trim();
     if (value === '_no response_') {
         return '';
     }

--- a/e2e-helper.js
+++ b/e2e-helper.js
@@ -26,6 +26,22 @@ async function performLogin() {
             await expect(error).toBeUndefined();
         }
     }
+
+
+    const currentUrl = await page.url();
+    if (currentUrl.includes('/sessions/two-factor')) {
+      if (!process.env.E2E_USER_2FA) {
+        // Account has 2fa enabled but E2E_USER_2FA is not set
+        process.exit(1);
+      }
+
+      await expect(page).toFill('#otp', process.env.E2E_USER_2FA);
+
+      await Promise.all([
+        page.waitForNavigation(),
+        expect(page).toClick('input[type=submit]', { value: 'Verify' }),
+      ]);
+    }
     
     console.log('Run E2E tests with authenticated user');
 };

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function toValue(val) {
         return val;
     }
 
-    const value = val.toLowerCase().trim();
+    const value = val.trim();
     if (value === '_no response_') {
         return '';
     }

--- a/test.spec.js
+++ b/test.spec.js
@@ -9,7 +9,7 @@ describe('End to End tests', () => {
     it('create issue', async () => {
         await createIssue('test-1.yml', 'test', {
             '#issue_form_contact': 'test@test.org',
-            'textarea[name="issue_form[what-happened]"]': 'something',
+            'textarea[name="issue_form[what-happened]"]': 'Something',
             'input[type="checkbox"][value="I agree"]': true,
             'input[type=radio][value="1.0.2 (Default)"]': true
         })
@@ -20,7 +20,7 @@ describe('End to End tests', () => {
     it('create issue text only', async () => {
         await createIssue('test-1.yml', 'test', {
             '#issue_form_contact': 'test@test.org',
-            'textarea[name="issue_form[what-happened]"]': 'something',
+            'textarea[name="issue_form[what-happened]"]': 'Something',
         })
 
         await assertActionResult();


### PR DESCRIPTION
I updated the e2e test to support `E2E_USER_2FA` so that I could test with my 2FA enabled test user account. That worked, but the test never completed, and I'm not sure why. So I coudln't verify that the test actually passed locally on my machine. But I did update the snapshots and test manually according with the issue.

closes #1