### PR TITLE
ci(test): run on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I would recommend we run the tests for pull requests. If you merge, I'd recommend to require the CI status before merging