### PR TITLE
document the issueparser_ outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Use this action to convert issues into a unified JSON structure.
     template-path: .github/ISSUE_TEMPLATE/bug-report.yml
 
 - run: echo '${{ steps.issue-parser.outputs.jsonString }}' > bug-details.json
+
+- run: echo '${{ steps.issue-parser.outputs.issueparser_your_contact_details }}'
 ```
 
 `template-path` is optional and meant to be used with Issue Forms.


### PR DESCRIPTION
When I stumbled into this action, I was hoping I wasn't going to have to write some `jq` statements ([like here](https://github.com/GitHub-Campus-IITM/support/blob/589e300a8d81a5fa74c1a72eae99e7d79891e40b/.github/workflows/hiring.yml#L18)) to parse the fields, but it looks like this action is awesome [and already adds each field as an output](https://github.com/stefanbuck/github-issue-parser/blob/7da1c3a96e2657d61f8fdd6555ee31be7410e617/index.js#L106). Just adding this as an example in the README!
