### PR TITLE
fix: Ensure releases can be pinned to SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,14 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: rm .gitignore # dist/ folder is ignored by default
-      - run: npx semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .gitignore dist/
           git commit -m "build"
           git push --force https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change will run `semantic-release` after updating the V2 branch to ensure the release tag points to the correct git sha