### PR TITLE
fix: `semantic-release` require node >= 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: "lts/*"
       - run: npm ci
       - run: npm run build
       - run: rm .gitignore # dist/ folder is ignored by default


### PR DESCRIPTION
See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md for more details and solutions.