### PR TITLE
Using env.runner_temp instead of home directory to write json file

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ async function run(env, body, fs, core) {
   }
 
   fs.writeFileSync(
-    `${env.USERPROFILE || env.HOME}/issue-parser-result.json`,
+    `${env.RUNNER_TEMP}/issue-parser-result.json`,
     jsonStringify(result),
     "utf-8"
   );


### PR DESCRIPTION
I was wondering what the issue parser json file was doing in my home directory with a self-hosted runner:
![image](https://github.com/stefanbuck/github-issue-parser/assets/19912012/cd88532c-2523-4202-941d-e7bdc5b2b6c4)

Changing this to use `${env.RUNNER_TEMP}` as a more GitHub-native way to store temporary files. 

> The path to a temporary directory on the runner. This directory is emptied at the beginning and end of each job. Note that files will not be removed if the runner's user account does not have permission to delete them. For example, `D:\a\_temp`

For Linux, it stores it under `<runner-dir>/_work/_temp`, and it's deleted after the job completes.  The file is no longer needed since the output var is being set.