### PR TITLE
feat: update to node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: '20'
       - run: npm ci
       - run: npm run build
       - run: rm .gitignore # dist/ folder is ignored by default

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ outputs:
   jsonString:
     description: 'JSON string'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: stefanbuck/github-issue-parser@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

😄 