### PR TITLE
fix(checkboxes): correctly parse checkboxes when the template is wrong or missing

### DIFF
--- a/fixtures/mismatched-parsing/expected.json
+++ b/fixtures/mismatched-parsing/expected.json
@@ -1,0 +1,9 @@
+{
+  "your_contact_details": "me@me.com",
+  "what_happened": "A bug happened!",
+  "version": "1.0.0",
+  "what_browsers_are_you_seeing_the_problem_on": "Chrome, Safari",
+  "what_else": ["Never give up"],
+  "and_with_that": ["Hot Dog is a Sandwich", "Another item"],
+  "checkbox_without_an_id": []
+}

--- a/fixtures/mismatched-parsing/form.yml
+++ b/fixtures/mismatched-parsing/form.yml
@@ -1,0 +1,16 @@
+body:
+  - type: input
+    id: favorite_dish
+    attributes:
+      label: What's your favorite dish?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: favorite_color
+    attributes:
+      label:  What's your preferred color?
+      options:
+        - label: Red
+        - label: Green
+        - label: Blue

--- a/fixtures/mismatched-parsing/issue-body.md
+++ b/fixtures/mismatched-parsing/issue-body.md
@@ -1,0 +1,31 @@
+### Your contact details
+
+me@me.com
+
+### What happened?
+
+A bug happened!
+
+### Version
+
+1.0.0
+
+### What browsers are you seeing the problem on?
+
+Chrome, Safari
+
+### What else?
+
+- [x] Never give up
+- [ ] Hot Dog is a Sandwich
+
+### And with that?
+
+- [] Never give up
+- [X] Hot Dog is a Sandwich
+- [x] Another item
+
+### Checkbox without an id?
+
+- [ ] IDs are great
+- [ ] IDs are bad

--- a/fixtures/mismatched-parsing/issue.js
+++ b/fixtures/mismatched-parsing/issue.js
@@ -1,0 +1,6 @@
+const { resolve } = require("path");
+const { readFileSync } = require("fs");
+
+const issueBodyPath = resolve(__dirname, "issue-body.md");
+
+module.exports = readFileSync(issueBodyPath, "utf-8");

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ async function run(env, body, fs, core) {
       if (key in result) {
         const content = result[key];
 
-        if (value !== undefined) {
+        if (content !== undefined && value !== undefined) {
           result[key] = content.concat(value);
         }
         return;
@@ -127,6 +127,9 @@ async function run(env, body, fs, core) {
               const field = check.replace(/- \[[X\s]\]\s+/i, "");
               const previousIndex = index === 0 ? index : index - 1;
               const key = arr[previousIndex].trim();
+              // set the type of the field to checkboxes to ensure that values will be represented as an array
+              // even when issue-form template is not provided or wrong template is provided
+              idTypes[toKey(key)] = "checkboxes";
               if (check.toUpperCase().startsWith("- [X] ")) {
                 return [key, field];
               }

--- a/test.spec.js
+++ b/test.spec.js
@@ -90,6 +90,50 @@ it("full example", () => {
   expect(core.setOutput.mock.calls.length).toBe(8)
 });
 
+it("mismatched parsing", () => {
+  const expectedOutput = require("./fixtures/mismatched-parsing/expected.json");
+  const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);
+
+  // mock ENV
+  const env = {
+    HOME: "<home path>",
+  };
+
+  // mock event payload
+  const eventPayload = require("./fixtures/mismatched-parsing/issue");
+
+  // mock fs
+  const fs = {
+    readFileSync(path, encoding) {
+      expect(path).toBe("<template-path>");
+      expect(encoding).toBe("utf8");
+      return readFileSync("fixtures/mismatched-parsing/form.yml", "utf-8");
+    },
+    writeFileSync(path, content) {
+      expect(path).toBe("<home path>/issue-parser-result.json");
+      expect(content).toBe(expectedOutputJson);
+    },
+  };
+
+  // mock core
+  const core = {
+    getInput: jest.fn(() => '<template-path>'),
+    setOutput: jest.fn(),
+  };
+
+  run(env, eventPayload, fs, core);
+  expect(core.getInput).toHaveBeenCalledWith('template-path')
+  expect(core.setOutput).toHaveBeenCalledWith('jsonString', JSON.stringify(expectedOutput, null, 2))
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_your_contact_details', 'me@me.com')
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_what_happened', 'A bug happened!')
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_version', '1.0.0')
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_what_browsers_are_you_seeing_the_problem_on', 'Chrome, Safari')
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_what_else', 'Never give up')
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_and_with_that', 'Hot Dog is a Sandwich,Another item')
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_checkbox_without_an_id', '')
+  expect(core.setOutput.mock.calls.length).toBe(8)
+});
+
 it("multiple paragraphs", () => {
   const expectedOutput = require("./fixtures/multiple-paragraphs/expected.json");
   const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);


### PR DESCRIPTION
When the wrong template is provided, then the action will traceback with the error:

```js
/home/runner/work/_actions/stefanbuck/github-issue-parser/v3/dist/index.js:105
          result[key] = content.concat(value);
                                ^

TypeError: Cannot read properties of undefined (reading 'concat')
    at /home/runner/work/_actions/stefanbuck/github-issue-parser/v3/dist/index.js:105:33
    at Array.forEach (<anonymous>)
    at toObject (/home/runner/work/_actions/stefanbuck/github-issue-parser/v3/dist/index.js:97:11)
    at run (/home/runner/work/_actions/stefanbuck/github-issue-parser/v3/dist/index.js:161:12)
    at 2932 (/home/runner/work/_actions/stefanbuck/github-issue-parser/v3/dist/index.js:184:3)
    at __nccwpck_require__ (/home/runner/work/_actions/stefanbuck/github-issue-parser/v3/dist/index.js:7097:43)
    at /home/runner/work/_actions/stefanbuck/github-issue-parser/v3/dist/index.js:7117:37
    at Object.<anonymous> (/home/runner/work/_actions/stefanbuck/github-issue-parser/v3/dist/index.js:7120:12)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
```

Also, checkboxes aren't represented as an array when the issue-form template is not provided.

This commit fixes both issues by correctly parsing checkboxes even when the template is wrong or missing.

Follow-up to:
- https://github.com/stefanbuck/github-issue-parser/pull/21

Related to:
- https://github.com/stefanbuck/github-issue-parser/issues/50

/cc @stefanbuck