### PR TITLE
fix: improve body parsing logic

### DIFF
--- a/fixtures/paragraph-confusing-####/expected.json
+++ b/fixtures/paragraph-confusing-####/expected.json
@@ -1,0 +1,3 @@
+{
+  "textarea-one": "Textarea input text 1 ####"
+}

--- a/fixtures/paragraph-confusing-####/form.yml
+++ b/fixtures/paragraph-confusing-####/form.yml
@@ -1,0 +1,9 @@
+body:
+  - type: textarea
+    id: textarea-one
+    attributes:
+      label: My textarea input
+  - type: textarea
+    id: textarea-two
+    attributes:
+      label: Another textarea input

--- a/fixtures/paragraph-confusing-####/issue-body.md
+++ b/fixtures/paragraph-confusing-####/issue-body.md
@@ -1,0 +1,3 @@
+### My textarea input
+
+Textarea input text 1 ####

--- a/fixtures/paragraph-confusing-####/issue.js
+++ b/fixtures/paragraph-confusing-####/issue.js
@@ -1,0 +1,6 @@
+const { resolve } = require("path");
+const { readFileSync } = require("fs");
+
+const issueBodyPath = resolve(__dirname, "issue-body.md");
+
+module.exports = readFileSync(issueBodyPath, "utf-8")

--- a/fixtures/paragraph-confusing-####/issue.js
+++ b/fixtures/paragraph-confusing-####/issue.js
@@ -1,6 +1,8 @@
-const { resolve } = require("path");
-const { readFileSync } = require("fs");
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const issueBodyPath = resolve(__dirname, "issue-body.md");
 
-module.exports = readFileSync(issueBodyPath, "utf-8")
+export default readFileSync(issueBodyPath, "utf-8");

--- a/fixtures/paragraph-ignore-```/expected.json
+++ b/fixtures/paragraph-ignore-```/expected.json
@@ -1,0 +1,3 @@
+{
+  "textarea-one": "Textarea input text 1\n\n```\n### To be ignored tag\n```"
+}

--- a/fixtures/paragraph-ignore-```/form.yml
+++ b/fixtures/paragraph-ignore-```/form.yml
@@ -1,0 +1,9 @@
+body:
+  - type: textarea
+    id: textarea-one
+    attributes:
+      label: My textarea input
+  - type: textarea
+    id: textarea-two
+    attributes:
+      label: Another textarea input

--- a/fixtures/paragraph-ignore-```/issue-body.md
+++ b/fixtures/paragraph-ignore-```/issue-body.md
@@ -1,0 +1,7 @@
+### My textarea input
+
+Textarea input text 1
+
+```
+### To be ignored tag
+```

--- a/fixtures/paragraph-ignore-```/issue.js
+++ b/fixtures/paragraph-ignore-```/issue.js
@@ -1,0 +1,6 @@
+const { resolve } = require("path");
+const { readFileSync } = require("fs");
+
+const issueBodyPath = resolve(__dirname, "issue-body.md");
+
+module.exports = readFileSync(issueBodyPath, "utf-8")

--- a/fixtures/paragraph-ignore-```/issue.js
+++ b/fixtures/paragraph-ignore-```/issue.js
@@ -1,6 +1,8 @@
-const { resolve } = require("path");
-const { readFileSync } = require("fs");
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const issueBodyPath = resolve(__dirname, "issue-body.md");
 
-module.exports = readFileSync(issueBodyPath, "utf-8")
+export default readFileSync(issueBodyPath, "utf-8");

--- a/fixtures/paragraph-ignore-```sh/expected.json
+++ b/fixtures/paragraph-ignore-```sh/expected.json
@@ -1,0 +1,3 @@
+{
+  "textarea-one": "Textarea input text 1\n\n```sh\n### To be ignored tag\n```"
+}

--- a/fixtures/paragraph-ignore-```sh/form.yml
+++ b/fixtures/paragraph-ignore-```sh/form.yml
@@ -1,0 +1,9 @@
+body:
+  - type: textarea
+    id: textarea-one
+    attributes:
+      label: My textarea input
+  - type: textarea
+    id: textarea-two
+    attributes:
+      label: Another textarea input

--- a/fixtures/paragraph-ignore-```sh/issue-body.md
+++ b/fixtures/paragraph-ignore-```sh/issue-body.md
@@ -1,0 +1,7 @@
+### My textarea input
+
+Textarea input text 1
+
+```sh
+### To be ignored tag
+```

--- a/fixtures/paragraph-ignore-```sh/issue.js
+++ b/fixtures/paragraph-ignore-```sh/issue.js
@@ -1,0 +1,6 @@
+const { resolve } = require("path");
+const { readFileSync } = require("fs");
+
+const issueBodyPath = resolve(__dirname, "issue-body.md");
+
+module.exports = readFileSync(issueBodyPath, "utf-8")

--- a/fixtures/paragraph-ignore-```sh/issue.js
+++ b/fixtures/paragraph-ignore-```sh/issue.js
@@ -1,6 +1,8 @@
-const { resolve } = require("path");
-const { readFileSync } = require("fs");
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const issueBodyPath = resolve(__dirname, "issue-body.md");
 
-module.exports = readFileSync(issueBodyPath, "utf-8")
+export default readFileSync(issueBodyPath, "utf-8");

--- a/index.js
+++ b/index.js
@@ -111,9 +111,35 @@ export async function run(env, body, fs, core) {
     return result
   }
 
-  result = body
-    .trim()
-    .split("###")
+  function parseBody(body) {
+    let result = [];
+    let ignore = false;
+
+    body.split("\n").reduce((str, line, idx, arr) => {
+      // ``` Section must be ignored and not parsed as new section
+      if (line.startsWith("```"))
+        ignore = !ignore
+
+      // Parse new setion only if they start with ### SPACE
+      if (!ignore && line.startsWith("### ")) {
+        result.push(str.trim())
+
+        return line.replace(/^### /, "")+"\n";
+      }
+
+      str += line + "\n"
+
+      // Push the last string if we are at the end of lines
+      if (arr.length - 1 == idx)
+        result.push(str.trim())
+
+      return str;
+    }, "")
+
+    return result;
+  }
+
+  result = parseBody(body)
     .filter(Boolean)
     .map((line) => {
       return line

--- a/test.spec.js
+++ b/test.spec.js
@@ -262,6 +262,45 @@ it("paragraph with ``` section", () => {
   expect(core.setOutput.mock.calls.length).toBe(2)
 });
 
+it("paragraph with ```sh section", () => {
+  const expectedOutput = require("./fixtures/paragraph-ignore-```sh/expected.json");
+  const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);
+
+  // mock ENV
+  const env = {
+    HOME: "<home path>",
+  };
+
+  // mock event payload
+  const eventPayload = require("./fixtures/paragraph-ignore-```sh/issue");
+
+  // mock fs
+  const fs = {
+    readFileSync(path, encoding) {
+      expect(path).toBe("<template-path>");
+      expect(encoding).toBe("utf8");
+      return readFileSync("fixtures/paragraph-ignore-```sh/form.yml", "utf-8");
+    },
+    writeFileSync(path, content) {
+      expect(path).toBe("<home path>/issue-parser-result.json");
+      expect(content).toBe(expectedOutputJson);
+    },
+  };
+
+  // mock core
+  const core = {
+    getInput: jest.fn(() => '<template-path>'),
+    setOutput: jest.fn(),
+  };
+
+  run(env, eventPayload, fs, core);
+
+  expect(core.getInput).toHaveBeenCalledWith('template-path')
+  expect(core.setOutput).toHaveBeenCalledWith('jsonString', JSON.stringify(expectedOutput, null, 2))
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_textarea-one', 'Textarea input text 1\n\n```sh\n### To be ignored tag\n```')
+  expect(core.setOutput.mock.calls.length).toBe(2)
+});
+
 it("blank", () => {
   const expectedOutput = loadJson("./fixtures/blank/expected.json");
   const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);

--- a/test.spec.js
+++ b/test.spec.js
@@ -7,6 +7,9 @@ import readmeExampleIssue from "./fixtures/readme-example/issue.js";
 import fullExampleIssue from "./fixtures/full-example/issue.js";
 import mismatchedParsingIssue from "./fixtures/mismatched-parsing/issue.js";
 import multipleParagraphsIssue from "./fixtures/multiple-paragraphs/issue.js";
+import paragraphConfusingHashesIssue from "./fixtures/paragraph-confusing-####/issue.js";
+import paragraphIgnoreCodeblockIssue from "./fixtures/paragraph-ignore-```/issue.js";
+import paragraphIgnoreCodeblockShIssue from "./fixtures/paragraph-ignore-```sh/issue.js";
 
 function loadJson(path) {
   return JSON.parse(readFileSync(path, "utf-8"));
@@ -185,7 +188,7 @@ it("multiple paragraphs", () => {
 });
 
 it("paragraph with confusing ####", () => {
-  const expectedOutput = require("./fixtures/paragraph-confusing-####/expected.json");
+  const expectedOutput = loadJson("./fixtures/paragraph-confusing-####/expected.json");
   const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);
 
   // mock ENV
@@ -194,7 +197,7 @@ it("paragraph with confusing ####", () => {
   };
 
   // mock event payload
-  const eventPayload = require("./fixtures/paragraph-confusing-####/issue");
+  const eventPayload = paragraphConfusingHashesIssue;
 
   // mock fs
   const fs = {
@@ -224,7 +227,7 @@ it("paragraph with confusing ####", () => {
 });
 
 it("paragraph with ``` section", () => {
-  const expectedOutput = require("./fixtures/paragraph-ignore-```/expected.json");
+  const expectedOutput = loadJson("./fixtures/paragraph-ignore-```/expected.json");
   const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);
 
   // mock ENV
@@ -233,7 +236,7 @@ it("paragraph with ``` section", () => {
   };
 
   // mock event payload
-  const eventPayload = require("./fixtures/paragraph-ignore-```/issue");
+  const eventPayload = paragraphIgnoreCodeblockIssue;
 
   // mock fs
   const fs = {
@@ -263,7 +266,7 @@ it("paragraph with ``` section", () => {
 });
 
 it("paragraph with ```sh section", () => {
-  const expectedOutput = require("./fixtures/paragraph-ignore-```sh/expected.json");
+  const expectedOutput = loadJson("./fixtures/paragraph-ignore-```sh/expected.json");
   const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);
 
   // mock ENV
@@ -272,7 +275,7 @@ it("paragraph with ```sh section", () => {
   };
 
   // mock event payload
-  const eventPayload = require("./fixtures/paragraph-ignore-```sh/issue");
+  const eventPayload = paragraphIgnoreCodeblockShIssue;
 
   // mock fs
   const fs = {

--- a/test.spec.js
+++ b/test.spec.js
@@ -223,6 +223,45 @@ it("paragraph with confusing ####", () => {
   expect(core.setOutput.mock.calls.length).toBe(2)
 });
 
+it("paragraph with ``` section", () => {
+  const expectedOutput = require("./fixtures/paragraph-ignore-```/expected.json");
+  const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);
+
+  // mock ENV
+  const env = {
+    HOME: "<home path>",
+  };
+
+  // mock event payload
+  const eventPayload = require("./fixtures/paragraph-ignore-```/issue");
+
+  // mock fs
+  const fs = {
+    readFileSync(path, encoding) {
+      expect(path).toBe("<template-path>");
+      expect(encoding).toBe("utf8");
+      return readFileSync("fixtures/paragraph-ignore-```/form.yml", "utf-8");
+    },
+    writeFileSync(path, content) {
+      expect(path).toBe("<home path>/issue-parser-result.json");
+      expect(content).toBe(expectedOutputJson);
+    },
+  };
+
+  // mock core
+  const core = {
+    getInput: jest.fn(() => '<template-path>'),
+    setOutput: jest.fn(),
+  };
+
+  run(env, eventPayload, fs, core);
+
+  expect(core.getInput).toHaveBeenCalledWith('template-path')
+  expect(core.setOutput).toHaveBeenCalledWith('jsonString', JSON.stringify(expectedOutput, null, 2))
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_textarea-one', 'Textarea input text 1\n\n```\n### To be ignored tag\n```')
+  expect(core.setOutput.mock.calls.length).toBe(2)
+});
+
 it("blank", () => {
   const expectedOutput = loadJson("./fixtures/blank/expected.json");
   const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);

--- a/test.spec.js
+++ b/test.spec.js
@@ -184,6 +184,45 @@ it("multiple paragraphs", () => {
   expect(core.setOutput.mock.calls.length).toBe(3)
 });
 
+it("paragraph with confusing ####", () => {
+  const expectedOutput = require("./fixtures/paragraph-confusing-####/expected.json");
+  const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);
+
+  // mock ENV
+  const env = {
+    HOME: "<home path>",
+  };
+
+  // mock event payload
+  const eventPayload = require("./fixtures/paragraph-confusing-####/issue");
+
+  // mock fs
+  const fs = {
+    readFileSync(path, encoding) {
+      expect(path).toBe("<template-path>");
+      expect(encoding).toBe("utf8");
+      return readFileSync("fixtures/paragraph-confusing-####/form.yml", "utf-8");
+    },
+    writeFileSync(path, content) {
+      expect(path).toBe("<home path>/issue-parser-result.json");
+      expect(content).toBe(expectedOutputJson);
+    },
+  };
+
+  // mock core
+  const core = {
+    getInput: jest.fn(() => '<template-path>'),
+    setOutput: jest.fn(),
+  };
+
+  run(env, eventPayload, fs, core);
+
+  expect(core.getInput).toHaveBeenCalledWith('template-path')
+  expect(core.setOutput).toHaveBeenCalledWith('jsonString', JSON.stringify(expectedOutput, null, 2))
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_textarea-one', 'Textarea input text 1 ####')
+  expect(core.setOutput.mock.calls.length).toBe(2)
+});
+
 it("blank", () => {
   const expectedOutput = loadJson("./fixtures/blank/expected.json");
   const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);


### PR DESCRIPTION
Current body parsing logic with trim() + split("###") is too fragile and
pose problems with some body that contains case with ### in the middle
of the line or case with codeblock ``` section.

These case will cause the script to parse these as separate section and
produce wrong outputs and in some case even prints error assuming things
are checkbox and errors out on the concat function.

To make the parsing logic more solid, implement a dedicated function and
parse with this logic:
- We split the body for "\n"
- We ignore codeblock ``` section
- We check "###" only at the start of the line
- We check for "### " (with the space included) as that is the correct
  section Github issue template expects.

With the following change case like:
```
root@OpenWrt:~# cat /boot/config.txt
```

Are correctly parsed as all part of a single section instead of being
wrongly treated as different empty sections.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>