### PR TITLE
fix: don't transform textarea with checkboxes into array

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35043,10 +35043,12 @@ async function run(env, body, fs, core) {
         .map((item, index, arr) => {
           const line = item.trim();
 
-          if (line.startsWith("- [")) {
+          // Allow the use of checkboxes in a textarea and transform the section into an array only when the section starts with a checkbox. 
+          // This doesn't cover the case when the textarea starts with a checkbox followed by text.
+          if (index === 1 && line.startsWith("- [")) {
             return line.split(/\r?\n/).map((check) => {
               const field = check.replace(/- \[[X\s]\]\s+/i, "");
-              const previousIndex = index === 0 ? index : index - 1;
+              const previousIndex = Math.max(0, index - 1);
               const key = arr[previousIndex].trim();
               // set the type of the field to checkboxes to ensure that values will be represented as an array
               // even when issue-form template is not provided or wrong template is provided

--- a/fixtures/checkboxes-in-textarea/expected.json
+++ b/fixtures/checkboxes-in-textarea/expected.json
@@ -1,0 +1,3 @@
+{
+  "description": "Some text:\n\n- [ ] Red\n- [ ] Green\n- [ ] Blue\n\nMore text"
+}

--- a/fixtures/checkboxes-in-textarea/form.yml
+++ b/fixtures/checkboxes-in-textarea/form.yml
@@ -1,0 +1,5 @@
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description

--- a/fixtures/checkboxes-in-textarea/issue-body.md
+++ b/fixtures/checkboxes-in-textarea/issue-body.md
@@ -1,0 +1,9 @@
+### Description
+
+Some text:
+
+- [ ] Red
+- [ ] Green
+- [ ] Blue
+
+More text

--- a/fixtures/checkboxes-in-textarea/issue.js
+++ b/fixtures/checkboxes-in-textarea/issue.js
@@ -1,0 +1,8 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const issueBodyPath = resolve(__dirname, "issue-body.md");
+
+export default readFileSync(issueBodyPath, "utf-8");

--- a/index.js
+++ b/index.js
@@ -148,10 +148,12 @@ export async function run(env, body, fs, core) {
         .map((item, index, arr) => {
           const line = item.trim();
 
-          if (line.startsWith("- [")) {
+          // Allow the use of checkboxes in a textarea and transform the section into an array only when the section starts with a checkbox. 
+          // This doesn't cover the case when the textarea starts with a checkbox followed by text.
+          if (index === 1 && line.startsWith("- [")) {
             return line.split(/\r?\n/).map((check) => {
               const field = check.replace(/- \[[X\s]\]\s+/i, "");
-              const previousIndex = index === 0 ? index : index - 1;
+              const previousIndex = Math.max(0, index - 1);
               const key = arr[previousIndex].trim();
               // set the type of the field to checkboxes to ensure that values will be represented as an array
               // even when issue-form template is not provided or wrong template is provided

--- a/test.spec.js
+++ b/test.spec.js
@@ -10,6 +10,7 @@ import multipleParagraphsIssue from "./fixtures/multiple-paragraphs/issue.js";
 import paragraphConfusingHashesIssue from "./fixtures/paragraph-confusing-####/issue.js";
 import paragraphIgnoreCodeblockIssue from "./fixtures/paragraph-ignore-```/issue.js";
 import paragraphIgnoreCodeblockShIssue from "./fixtures/paragraph-ignore-```sh/issue.js";
+import checkboxesInTextareaIssue from "./fixtures/checkboxes-in-textarea/issue.js";
 
 function loadJson(path) {
   return JSON.parse(readFileSync(path, "utf-8"));
@@ -301,6 +302,45 @@ it("paragraph with ```sh section", () => {
   expect(core.getInput).toHaveBeenCalledWith('template-path')
   expect(core.setOutput).toHaveBeenCalledWith('jsonString', JSON.stringify(expectedOutput, null, 2))
   expect(core.setOutput).toHaveBeenCalledWith('issueparser_textarea-one', 'Textarea input text 1\n\n```sh\n### To be ignored tag\n```')
+  expect(core.setOutput.mock.calls.length).toBe(2)
+});
+
+it("checkboxes in textarea", () => {
+  const expectedOutput = loadJson("./fixtures/checkboxes-in-textarea/expected.json");
+  const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);
+
+  // mock ENV
+  const env = {
+    HOME: "<home path>",
+  };
+
+  // mock event payload
+  const eventPayload = checkboxesInTextareaIssue;
+
+  // mock fs
+  const fs = {
+    readFileSync(path, encoding) {
+      expect(path).toBe("<template-path>");
+      expect(encoding).toBe("utf8");
+      return readFileSync("fixtures/checkboxes-in-textarea/form.yml", "utf-8");
+    },
+    writeFileSync(path, content) {
+      expect(path).toBe("<home path>/issue-parser-result.json");
+      expect(content).toBe(expectedOutputJson);
+    },
+  };
+
+  // mock core
+  const core = {
+    getInput: jest.fn(() => '<template-path>'),
+    setOutput: jest.fn(),
+  };
+
+  run(env, eventPayload, fs, core);
+
+  expect(core.getInput).toHaveBeenCalledWith('template-path')
+  expect(core.setOutput).toHaveBeenCalledWith('jsonString', JSON.stringify(expectedOutput, null, 2))
+  expect(core.setOutput).toHaveBeenCalledWith('issueparser_description', 'Some text:\n\n- [ ] Red\n- [ ] Green\n- [ ] Blue\n\nMore text')
   expect(core.setOutput.mock.calls.length).toBe(2)
 });
 


### PR DESCRIPTION
Allow the use of checkboxes in a textarea and transform the section into an array only when the section starts with a checkbox. 

This doesn't cover the case when the textarea starts with a checkbox followed by text.

Fixes: #90 